### PR TITLE
The esgf-publisher requires 0.7.11, favor those requirements to these

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ django-simple-captcha==0.5.1
 html5lib==1.0b8
 bleach==1.4.2
 python-magic==0.4.12
-esgfpid==0.7.10
+esgfpid


### PR DESCRIPTION
When running `esgtest_publish` post install the following error message was generated.
```
Publish dataset
Step 1: Publish to Postgres, Running "esgpublish --project test --map /tmp/test.1538383354 --service fileservice --keep-credentials"... [FAIL]
ERROR:
Traceback (most recent call last):
  File "/usr/local/conda/envs/esgf-pub/bin/esgpublish", line 754, in <module>
    main(sys.argv[1:])
  File "/usr/local/conda/envs/esgf-pub/bin/esgpublish", line 595, in main
    registerHandlers(projectName)
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/esgcet/config/config.py", line 434, in registerHandlers
    registerHandlerName(projectRegistry, projectName, handlerName)
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/esgcet/config/registry.py", line 151, in registerHandlerName
    registry.registerHandlerName(projectName, handlerName)
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/esgcet/config/registry.py", line 122, in registerHandlerName
    self.entry_points = self.loadEntryPoints()
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/esgcet/config/registry.py", line 84, in loadEntryPoints
    handlerDict = v[HANDLER_DICT_ENTRY_POINT].load()
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2331, in load
    self.require(*args, **kwargs)
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2354, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (esgfpid 0.7.10 (/usr/local/conda/envs/esgf-pub/lib/python2.7/site-packages), Requirement.parse('esgfpid>=0.7.11'))
```
Causing the test to fail.