### PR TITLE
Add rootAdmin to the wheel group and super role at creation

### DIFF
--- a/cog/installation/constants.py
+++ b/cog/installation/constants.py
@@ -15,6 +15,8 @@ IDP_WHITELIST = "%s/esgf_idp.xml, %s/esgf_idp_static.xml" % (ESG_CONFIG_DIR, ESG
 ESGF_ROOTADMIN_PASSWORD_FILE = '%s/.esgf_pass' % ESG_CONFIG_DIR
 ROOTADMIN_USERNAME = "rootAdmin"
 DEFAULT_ROOTADMIN_PWD = "changeit"
+ROOTADMIN_GROUP = "wheel"
+ROOTADMIN_ROLE = "super"
 KNOWN_PROVIDERS = "%s/esgf_known_providers.xml" % ESG_CONFIG_DIR
 PEER_NODES = "%s/esgf_cogs.xml" % ESG_CONFIG_DIR
 

--- a/cog/installation/install.py
+++ b/cog/installation/install.py
@@ -18,7 +18,10 @@ from cog.models import PeerSite
 from cog.views.views_project import initProject
 
 from cog.installation.constants import (DEFAULT_PROJECT_SHORT_NAME, ESGF_ROOTADMIN_PASSWORD_FILE, 
-                                        DEFAULT_ROOTADMIN_PWD, ROOTADMIN_USERNAME)
+                                        DEFAULT_ROOTADMIN_PWD, ROOTADMIN_USERNAME, ROOTADMIN_GROUP,
+                                        ROOTADMIN_ROLE)
+
+from cog.services.registration.registration_impl import esgfRegistrationServiceImpl
 from cog.plugins.esgf.security import esgfDatabaseManager
 from django_openid_auth.models import UserOpenID
 from django.core.exceptions import ObjectDoesNotExist
@@ -152,7 +155,7 @@ class CoGInstall(object):
                 # insert rootAdmin user in ESGF database
                 logging.info("Inserting CoG administrator: %s in ESGF database" % user.username)
                 esgfDatabaseManager.insertEsgfUser(user.profile)
-
+                esgfRegistrationServiceImpl.subscribe(openid, ROOTADMIN_GROUP, ROOTADMIN_ROLE)
             
         # must create and enable 'esgf.idp.peer" as federated CoG peer
         if settings.IDP_REDIRECT is not None and settings.IDP_REDIRECT.strip()  != '':


### PR DESCRIPTION
This uses Cog's utilities to add the rootAdmin user to the wheel group and super role at creation.